### PR TITLE
Shader injection causes a compile error

### DIFF
--- a/src/main/resources/assets/psychedelicraft/shaders/geometry/basic.gfsh
+++ b/src/main/resources/assets/psychedelicraft/shaders/geometry/basic.gfsh
@@ -12,7 +12,7 @@ ps_out vec4 fragColor;
 
 void main() {
   // Write to it so mac is happy
-  fragColor = vec4(0, 0, 0, 0);
+  vec4 fragColor = vec4(0, 0, 0, 0);
   i_parent_shaders_main();
 
   float worldTicks = PS_WorldTicks;


### PR DESCRIPTION
Hi there, I am the developer of Euphoria Patches, an add-on for Complementary shaders and I noticed that this mod injects shaders code into shaderpacks.
Currently, this causes a compile error as fragColor is undeclared. See screenshot. This is in the final fragment shader. And no, there is no `in vec4 fragColor`

I don't know if this is the only issue. This means that I did not test this locally and only fixed the issue I know about. If this is fixed, there is still a possibility that other compile errors exist which did not appear as the current one exists. I do hope that this is the only one :)

```
[14:00:00] [Render thread/ERROR]: Failed to create shader rendering pipeline, disabling shaders!
net.irisshaders.iris.gl.shader.ShaderCompileException: final.fsh: final.fsh: ERROR: 0:1391: 'fragColor' : undeclared identifier 
ERROR: 0:1391: '' : compilation terminated 
ERROR: 2 compilation errors.  No code generated.
```

![Image](https://github.com/user-attachments/assets/9fe6d449-11f5-4135-966a-24f3b4026b4b)

![Image](https://github.com/user-attachments/assets/1a8cbc14-bb4a-4419-aaba-1fe0c1e8baa8)